### PR TITLE
Feature/defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Mark models as `has_publishing` to publish, draft and embargo models. Easy peasy
 ## Features
 
 * `published`, `draft`, `embargoed` scopes for easy filtering/finding
-* Rails environment-based default scoping: if your site is using `production`, draft/embargoed records will still be found - if you use `RAILS_ENV=production_published`, though, only published records will be found.
+* Rails environment-based default scoping: if your site is using `draft`, draft/embargoed records will still be found - if you use `RAILS_ENV=published`, though, only published records will be found.
 * In use in production on multiple sites
 * Covered by automated tests
 
@@ -41,14 +41,13 @@ bundle exec rails generate migration [YOUR MODEL NAME] embargoed_until:datetime 
 
 Publishing is typically used in an environment where there may be two installations of the Rails application sharing a common database. This at least is the set up that `has_publishing` is designed to operate in - something like the following:
 
-
 ```
 |-- Admin RAILS_ENV=draft --| >>>>> SharedDatabase <<<<<< |-- Published Site RAILS_ENV=published --|
 ```
 
 Because of this, the gem applies a default_scope to all instances of this model to either:
 
-* Only return published records if `Rails.env` matches `HasPublishing.config.published_rails_environment`
+* Only return published records if `Rails.env` matches `HasPublishing.config.published_rails_environment` (which by default is ``` 'published' ```)
 * Only return draft records otherwise
 
 This prevents 'duplicate' records from appearing for the user (since each 'record' has two representations - 'draft' and 'published/withdrawn')

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Publishing is typically used in an environment where there may be two installati
 
 Because of this, the gem applies a default_scope to all instances of this model to either:
 
-* Only return published records if `Rails.env` matches `HasPublishing.config.published_rails_environment` (which by default is ``` 'published' ```)
+* Only return published records if `Rails.env` matches `HasPublishing.config.published_rails_environment` (which by default is `'published'`)
 * Only return draft records otherwise
 
 This prevents 'duplicate' records from appearing for the user (since each 'record' has two representations - 'draft' and 'published/withdrawn')

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Publishing is typically used in an environment where there may be two installati
 
 
 ```
-|-- Admin RAILS_ENV=production --| >>>>> SharedDatabase <<<<<< |-- Published Site RAILS_ENV=production_published --|
+|-- Admin RAILS_ENV=draft --| >>>>> SharedDatabase <<<<<< |-- Published Site RAILS_ENV=published --|
 ```
 
 Because of this, the gem applies a default_scope to all instances of this model to either:

--- a/lib/has_publishing/configuration.rb
+++ b/lib/has_publishing/configuration.rb
@@ -3,5 +3,5 @@ module HasPublishing
 
   # Set some default config
   self.config.scope_records = true
-  self.config.published_rails_environment = "production"
+  self.config.published_rails_environment = "published"
 end

--- a/spec/has_publishing_spec.rb
+++ b/spec/has_publishing_spec.rb
@@ -67,7 +67,7 @@ describe "has_publishing" do
 
   describe "default configuration" do
     it { HasPublishing.config.scope_records.should be_true }
-    it { HasPublishing.config.published_rails_environment.should eq "production" }
+    it { HasPublishing.config.published_rails_environment.should eq "published" }
   end
 
 


### PR DESCRIPTION
This pull request changes the default environment `has_publishing` uses to scope records against.
- Change `has_publishing` default published_rails_environment to `"published"`
- Change readme to cover config changes and also make a few things clearer
